### PR TITLE
Fields for new related record should be cleared

### DIFF
--- a/RelationTrait.php
+++ b/RelationTrait.php
@@ -97,6 +97,9 @@ trait RelationTrait
                         if (in_array($name, $skippedRelations))
                             continue;
 
+                        unset($fields);
+                        $fields = array();
+                        
                         if (!empty($records)) {
                             $AQ = $this->getRelation($name);
                             $link = $AQ->link;


### PR DESCRIPTION
Fields keeps on accumulating the fields even if related record does not have the field.
